### PR TITLE
Nekopost - Search Error "HTTP 404" Fixed

### DIFF
--- a/src/th/nekopost/build.gradle
+++ b/src/th/nekopost/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Nekopost'
     extClass = '.Nekopost'
-    extVersionCode = 12
+    extVersionCode = 13
     isNsfw = true
 }
 

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
@@ -211,7 +211,6 @@ class Nekopost : HttpSource() {
                     thumbnail_url = "$fileHost/collectManga/${it.pid}/${it.pid}_cover.jpg?ver=${it.coverVersion}"
                 }
             }
-
         return MangasPage(mangaList, false)
     }
 }

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
@@ -6,7 +6,6 @@ import eu.kanade.tachiyomi.extension.th.nekopost.model.RawProjectInfo
 import eu.kanade.tachiyomi.extension.th.nekopost.model.RawProjectSearchSummaryList
 import eu.kanade.tachiyomi.extension.th.nekopost.model.RawProjectSummaryList
 import eu.kanade.tachiyomi.extension.th.nekopost.model.SearchRequest
-import eu.kanade.tachiyomi.lib.cryptoaes.CryptoAES
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -186,7 +185,7 @@ class Nekopost : HttpSource() {
 
         val pagingData = PagingRequest(
             pageNo = page,
-            pageSize = 20,
+            pageSize = 100,
         )
         val searchData = SearchRequest(
             keyword = query,
@@ -199,17 +198,17 @@ class Nekopost : HttpSource() {
 
     override fun searchMangaParse(response: Response): MangasPage {
         val responseBody = response.body.string()
-        val decrypted = CryptoAES.decrypt(responseBody, "AeyTest")
 
-        val projectList: RawProjectSearchSummaryList = json.decodeFromString(decrypted)
+        val projectList: RawProjectSearchSummaryList = json.decodeFromString(responseBody)
+
         val mangaList: List<SManga> = projectList.listProject
             .filter { it.projectType == "m" }
             .map {
                 SManga.create().apply {
-                    url = it.projectId.toString()
+                    url = it.pid.toString()
                     title = it.projectName
                     status = it.status
-                    thumbnail_url = "$fileHost/collectManga/${it.projectId}/${it.projectId}_cover.jpg?ver=${it.coverVersion}"
+                    thumbnail_url = "$fileHost/collectManga/${it.pid}/${it.pid}_cover.jpg?ver=${it.coverVersion}"
                 }
             }
 

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/Nekopost.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.th.nekopost
 
+import eu.kanade.tachiyomi.extension.th.nekopost.model.PagingRequest
 import eu.kanade.tachiyomi.extension.th.nekopost.model.RawChapterInfo
 import eu.kanade.tachiyomi.extension.th.nekopost.model.RawProjectInfo
 import eu.kanade.tachiyomi.extension.th.nekopost.model.RawProjectSearchSummaryList
@@ -178,9 +179,22 @@ class Nekopost : HttpSource() {
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val headers = Headers.headersOf("accept", "*/*", "content-type", "text/plain;charset=UTF-8", "origin", baseUrl)
-        val requestBody = Json.encodeToString(SearchRequest(query, page)).toRequestBody()
-        return POST("$baseUrl/api/explore/search", headers, requestBody)
+        val searchHeaders = headersBuilder()
+            .set("Accept", "*/*")
+            .set("Content-Type", "application/json")
+            .build()
+
+        val pagingData = PagingRequest(
+            pageNo = page,
+            pageSize = 20,
+        )
+        val searchData = SearchRequest(
+            keyword = query,
+            status = 0,
+            paging = pagingData,
+        )
+        val requestBody = Json.encodeToString(searchData).toRequestBody()
+        return POST("$baseUrl/api/project/search", searchHeaders, requestBody)
     }
 
     override fun searchMangaParse(response: Response): MangasPage {

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/RawProjectSearchSummary.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/RawProjectSearchSummary.kt
@@ -1,19 +1,42 @@
 package eu.kanade.tachiyomi.extension.th.nekopost.model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class RawProjectSearchSummary(
-    val projectId: Int,
+    val pid: Int,
     val projectName: String,
-    val projectType: String,
-    @SerialName("STATUS")
-    val status: Int,
-    val noChapter: Int,
-    val coverVersion: Int,
-    val info: String,
-    val views: Int,
-    @SerialName("lastUpdate")
-    val lastUpdateDate: String,
+    val aliasName: String = "",
+    val website: String = "",
+    val authorId: Int = 0,
+    val authorName: String = "",
+    val artistId: Int = 0,
+    val artistName: String = "",
+    val info: String = "",
+    val status: Int = 0,
+    val flgMature: String = "",
+    val flgIntense: String = "",
+    val flgViolent: String = "",
+    val flgGlue: String = "",
+    val flgReligion: String = "",
+    val flgHidemeta: String = "",
+    val mainCategory: String = "",
+    val goingType: String = "",
+    val projectType: String = "",
+    val readerGroup: String = "",
+    val releaseDate: ProjectDate = ProjectDate(),
+    val updateDate: ProjectDate = ProjectDate(),
+    val views: Int = 0,
+    val imageVersion: Int = 0,
+    val noChapter: Int = 0,
+    val coverVersion: Int = 0,
+    val concatCate: String = "",
+    val editorId: Int = 0,
+    val editorName: String = "",
+)
+
+@Serializable
+data class ProjectDate(
+    val String: String = "",
+    val Valid: Boolean = false,
 )

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/RawProjectSearchSummaryList.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/RawProjectSearchSummaryList.kt
@@ -5,5 +5,4 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RawProjectSearchSummaryList(
     val listProject: List<RawProjectSearchSummary>,
-    val totalRecord: String,
 )

--- a/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/SearchRequest.kt
+++ b/src/th/nekopost/src/eu/kanade/tachiyomi/extension/th/nekopost/model/SearchRequest.kt
@@ -3,7 +3,14 @@ package eu.kanade.tachiyomi.extension.th.nekopost.model
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class PagingRequest(
+    val pageNo: Int,
+    val pageSize: Int,
+)
+
+@Serializable
 data class SearchRequest(
     val keyword: String,
-    val pageNo: Int,
+    val status: Int = 0,
+    val paging: PagingRequest,
 )


### PR DESCRIPTION
### Closes [Nekopost - Search Error "HTTP 404" #9549](https://github.com/keiyoushi/extensions-source/issues/9549)

## Changes:
- update data model dedicate to new api
- update url for search api
- change header building method in searchMangaRequest

## Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
